### PR TITLE
Empty Hyperlinks

### DIFF
--- a/src/blobs.coffee
+++ b/src/blobs.coffee
@@ -160,7 +160,7 @@ module.exports =
             out += "</hyperlinks>"
             return out
         else
-            return "";
+            return ""
 
     # Printed in xl/worksheets/_rels/sheet1.xml.rels
     externalWorksheetRels: (relationships) ->

--- a/src/blobs.coffee
+++ b/src/blobs.coffee
@@ -153,11 +153,14 @@ module.exports =
 
     # Printed inside worksheet
     worksheetRels: (relationships) ->
-        out = "<hyperlinks>"
-        for rel, i in relationships
-            out += """<hyperlink ref="#{rel.cell}" r:id="rId#{i + 1}" />"""
-        out += "</hyperlinks>"
-        return out
+        if relationships.length > 0
+            out = "<hyperlinks>"
+            for rel, i in relationships
+                out += """<hyperlink ref="#{rel.cell}" r:id="rId#{i + 1}" />"""
+            out += "</hyperlinks>"
+            return out
+        else
+            return "";
 
     # Printed in xl/worksheets/_rels/sheet1.xml.rels
     externalWorksheetRels: (relationships) ->


### PR DESCRIPTION
To fix issue #3 where a spreadsheet has no relationships, an empty <hyperlinks /> node will create an invalid xlsx file.