### PR TITLE
A string containing a number should remain as text

### DIFF
--- a/src/index.litcoffee
+++ b/src/index.litcoffee
@@ -268,7 +268,7 @@ Adds a cell to the row in progress.
           @_createRelationship(cell, value.hyperlink)
           return
 
-        if typeof value == 'number' or numberRegex.test(value)
+        if typeof value == 'number'
           @rowBuffer += blobs.numberCell(value, cell)
         else if value instanceof Date
           date = @_dateToOADate(value)


### PR DESCRIPTION
Adding "1234" to a sheet should be added to the spreadsheet as a text field, not converted to a number. We can already add number fields by adding the value 1234 instead.