### PR TITLE
Fix when row[key] == 0

### DIFF
--- a/src/index.litcoffee
+++ b/src/index.litcoffee
@@ -112,7 +112,8 @@ Add a single row.
 
         @_startRow()
         for key, col in @cellMap
-          @_addCell(row[key] || "", col + 1)
+          value = if row[key] == undefined or row[key] == null then '' else row[key]
+          @_addCell(value, col + 1)
         @_endRow()
 
 ##### addRows(rows: Array)


### PR DESCRIPTION
When row [key] is 0 is sent '', this is wrong. Now it validates if row[key] is undefined or null and only in that case is sent ''.